### PR TITLE
common, examples: add new MS STL <chrono> references, fixing breaking changes

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -14,6 +14,7 @@
 #include <cinttypes>
 #include <climits>
 #include <cmath>
+#include <chrono>
 #include <codecvt>
 #include <cstdarg>
 #include <cstring>

--- a/common/log.cpp
+++ b/common/log.cpp
@@ -1,5 +1,6 @@
 #include "log.h"
 
+#include <chrono>
 #include <condition_variable>
 #include <cstdarg>
 #include <cstdio>

--- a/examples/imatrix/imatrix.cpp
+++ b/examples/imatrix/imatrix.cpp
@@ -3,6 +3,7 @@
 #include "log.h"
 #include "llama.h"
 
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <cstring>

--- a/examples/perplexity/perplexity.cpp
+++ b/examples/perplexity/perplexity.cpp
@@ -3,6 +3,7 @@
 #include "log.h"
 #include "llama.h"
 
+#include <chrono>
 #include <algorithm>
 #include <array>
 #include <atomic>


### PR DESCRIPTION
Whereas https://github.com/microsoft/STL/pull/5105 moved various "chrono" solutions to the lib `<chrono>`, creating a breaking change, this update applies an update to correct that when using the latest STL, and https://github.com/ggml-org/llama.cpp/pull/11836 in the upstream `llama.cpp` makes a corrective action of a similar nature, the change requested here should should be worthwhile to accept, too.

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [x] Medium
  - [ ] High
