### PR TITLE
[feat] Add Gemma3 architecture support with per-projection RMSNorm for BitNet embedding 270m

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1331,12 +1331,15 @@ endif()
 #
 
 # ggml
+if (GGML_BITNET_ARM_TL1 OR GGML_BITNET_X86_TL2)
+    set(BITNET_LUT_HEADER ../../../../include/bitnet-lut-kernels.h)
+endif()
 
 add_library(ggml
             ../include/ggml.h
             ../include/ggml-alloc.h
             ../include/ggml-backend.h
-            ../../../../include/bitnet-lut-kernels.h
+            ${BITNET_LUT_HEADER}
             ../../../../include/ggml-bitnet.h
             ggml.c
             ggml-alloc.c

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -10268,6 +10268,81 @@ static void ggml_compute_forward_mul_f32(
     }
 }
 
+// ggml_compute_forward_mul_f32_f16
+// src0: F32, src1: F16 (e.g., norm weights stored as f16)
+
+static void ggml_compute_forward_mul_f32_f16(
+        const struct ggml_compute_params * params,
+        struct ggml_tensor * dst) {
+
+    const struct ggml_tensor * src0 = dst->src[0];
+    const struct ggml_tensor * src1 = dst->src[1];
+
+    GGML_ASSERT(ggml_can_repeat(src1, src0) && ggml_are_same_shape(src0, dst));
+
+    const int ith = params->ith;
+    const int nth = params->nth;
+
+    const int64_t nr = ggml_nrows(src0);
+
+    GGML_TENSOR_BINARY_OP_LOCALS
+
+    GGML_ASSERT( nb0 == sizeof(float));
+    GGML_ASSERT(nb00 == sizeof(float));
+
+    if (ggml_nelements(src1) == 1) {
+        float scale = GGML_FP16_TO_FP32(((ggml_fp16_t *) src1->data)[0]);
+        for (int64_t ir = ith; ir < nr; ir += nth) {
+            if (dst->data != src0->data) {
+                memcpy((char *)dst->data + ir*nb1, (char *)src0->data + ir*nb01, ne0 * sizeof(float));
+            }
+            ggml_vec_scale_f32(ne0, (float *) ((char *) dst->data + ir*nb1), scale);
+        }
+    } else if (nb10 == sizeof(ggml_fp16_t)) {
+        for (int64_t ir = ith; ir < nr; ir += nth) {
+            const int64_t i03 = ir/(ne02*ne01);
+            const int64_t i02 = (ir - i03*ne02*ne01)/ne01;
+            const int64_t i01 = (ir - i03*ne02*ne01 - i02*ne01);
+
+            const int64_t i13 = i03 % ne13;
+            const int64_t i12 = i02 % ne12;
+            const int64_t i11 = i01 % ne11;
+            const int64_t nr0 = ne00 / ne10;
+
+            float       * dst_ptr  = (float *)       ((char *) dst->data  + i03*nb3  + i02*nb2  + i01*nb1 );
+            float       * src0_ptr = (float *)       ((char *) src0->data + i03*nb03 + i02*nb02 + i01*nb01);
+            ggml_fp16_t * src1_ptr = (ggml_fp16_t *) ((char *) src1->data + i13*nb13 + i12*nb12 + i11*nb11);
+
+            for (int64_t r = 0; r < nr0; ++r) {
+                for (int64_t i = 0; i < ne10; ++i) {
+                    dst_ptr[r*ne10 + i] = src0_ptr[r*ne10 + i] * GGML_FP16_TO_FP32(src1_ptr[i]);
+                }
+            }
+        }
+    } else {
+        // src1 is not contiguous
+        for (int64_t ir = ith; ir < nr; ir += nth) {
+            const int64_t i03 = ir/(ne02*ne01);
+            const int64_t i02 = (ir - i03*ne02*ne01)/ne01;
+            const int64_t i01 = (ir - i03*ne02*ne01 - i02*ne01);
+
+            const int64_t i13 = i03 % ne13;
+            const int64_t i12 = i02 % ne12;
+            const int64_t i11 = i01 % ne11;
+
+            float * dst_ptr  = (float *) ((char *) dst->data  + i03*nb3  + i02*nb2  + i01*nb1 );
+            float * src0_ptr = (float *) ((char *) src0->data + i03*nb03 + i02*nb02 + i01*nb01);
+
+            for (int64_t i0 = 0; i0 < ne00; ++i0) {
+                const int64_t i10 = i0 % ne10;
+                ggml_fp16_t * src1_ptr = (ggml_fp16_t *) ((char *) src1->data + i13*nb13 + i12*nb12 + i11*nb11 + i10*nb10);
+
+                dst_ptr[i0] = src0_ptr[i0] * GGML_FP16_TO_FP32(*src1_ptr);
+            }
+        }
+    }
+}
+
 static void ggml_compute_forward_mul(
         const struct ggml_compute_params * params,
         struct ggml_tensor * dst) {
@@ -10275,12 +10350,16 @@ static void ggml_compute_forward_mul(
     const struct ggml_tensor * src0 = dst->src[0];
     const struct ggml_tensor * src1 = dst->src[1];
 
-    GGML_ASSERT(src1->type == GGML_TYPE_F32 && "only f32 src1 supported for now");
-
     switch (src0->type) {
         case GGML_TYPE_F32:
             {
-                ggml_compute_forward_mul_f32(params, dst);
+                if (src1->type == GGML_TYPE_F32) {
+                    ggml_compute_forward_mul_f32(params, dst);
+                } else if (src1->type == GGML_TYPE_F16) {
+                    ggml_compute_forward_mul_f32_f16(params, dst);
+                } else {
+                    GGML_ABORT("ggml_compute_forward_mul: unsupported src1 type");
+                }
             } break;
         default:
             {

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -1428,6 +1428,7 @@ class GGMLQuantizationType(IntEnum):
     Q4_0_8_8 = 33
     TQ1_0   = 34
     TQ2_0   = 35
+    I2_S    = 36
     TL1     = 38
     TL2     = 39
 
@@ -1554,6 +1555,7 @@ GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
     GGMLQuantizationType.Q4_0_8_8:(32, 2 + 16),
     GGMLQuantizationType.TQ1_0:   (256, 2 + 4 * 13),
     GGMLQuantizationType.TQ2_0:   (256, 2 + 64),
+    GGMLQuantizationType.I2_S:     (4, 1),
     GGMLQuantizationType.TL1:      (4, 1),
     GGMLQuantizationType.TL2:      (4, 1),
 }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -215,6 +215,7 @@ enum llm_arch {
     LLM_ARCH_GRANITE,
     LLM_ARCH_GRANITE_MOE,
     LLM_ARCH_CHAMELEON,
+    LLM_ARCH_QWEN3,
     LLM_ARCH_UNKNOWN,
 };
 
@@ -269,8 +270,9 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
     { LLM_ARCH_RWKV6,           "rwkv6"        },
     { LLM_ARCH_GRANITE,         "granite"      },
     { LLM_ARCH_GRANITE_MOE,     "granitemoe"   },
-    { LLM_ARCH_CHAMELEON,       "chameleon"    },
-    { LLM_ARCH_UNKNOWN,         "(unknown)"    },
+    { LLM_ARCH_CHAMELEON,        "chameleon"        },
+    { LLM_ARCH_QWEN3,            "qwen3"            },
+    { LLM_ARCH_UNKNOWN,          "(unknown)"        },
 };
 
 enum llm_kv {
@@ -594,6 +596,13 @@ enum llm_tensor {
     LLM_TENSOR_ATTN_KV_A_NORM,
     LLM_TENSOR_ATTN_SUB_NORM,
     LLM_TENSOR_FFN_SUB_NORM,
+    LLM_TENSOR_ATTN_Q_NORM_IN,
+    LLM_TENSOR_ATTN_K_NORM_IN,
+    LLM_TENSOR_ATTN_V_NORM_IN,
+    LLM_TENSOR_ATTN_OUT_NORM_IN,
+    LLM_TENSOR_FFN_GATE_NORM_IN,
+    LLM_TENSOR_FFN_UP_NORM_IN,
+    LLM_TENSOR_FFN_DOWN_NORM_IN,
     LLM_TENSOR_DEC_ATTN_NORM,
     LLM_TENSOR_DEC_ATTN_Q,
     LLM_TENSOR_DEC_ATTN_K,
@@ -1128,6 +1137,32 @@ static const std::map<llm_arch, std::map<llm_tensor, const char *>> LLM_TENSOR_N
             { LLM_TENSOR_FFN_DOWN,        "blk.%d.ffn_down" },
             { LLM_TENSOR_FFN_UP,          "blk.%d.ffn_up" },
             { LLM_TENSOR_FFN_POST_NORM,   "blk.%d.post_ffw_norm" },
+        },
+    },
+    {
+        LLM_ARCH_QWEN3,
+        {
+            { LLM_TENSOR_TOKEN_EMBD,      "token_embd" },
+            { LLM_TENSOR_OUTPUT_NORM,     "output_norm" },
+            { LLM_TENSOR_OUTPUT,          "output" },
+            { LLM_TENSOR_ATTN_NORM,       "blk.%d.attn_norm" },
+            { LLM_TENSOR_ATTN_Q,          "blk.%d.attn_q" },
+            { LLM_TENSOR_ATTN_K,          "blk.%d.attn_k" },
+            { LLM_TENSOR_ATTN_V,          "blk.%d.attn_v" },
+            { LLM_TENSOR_ATTN_OUT,        "blk.%d.attn_output" },
+            { LLM_TENSOR_ATTN_Q_NORM,     "blk.%d.attn_q_norm" },
+            { LLM_TENSOR_ATTN_K_NORM,     "blk.%d.attn_k_norm" },
+            { LLM_TENSOR_ATTN_Q_NORM_IN,  "blk.%d.attn_q_norm_in" },
+            { LLM_TENSOR_ATTN_K_NORM_IN,  "blk.%d.attn_k_norm_in" },
+            { LLM_TENSOR_ATTN_V_NORM_IN,  "blk.%d.attn_v_norm_in" },
+            { LLM_TENSOR_ATTN_OUT_NORM_IN,"blk.%d.attn_output_norm_in" },
+            { LLM_TENSOR_FFN_NORM,        "blk.%d.ffn_norm" },
+            { LLM_TENSOR_FFN_GATE,        "blk.%d.ffn_gate" },
+            { LLM_TENSOR_FFN_DOWN,        "blk.%d.ffn_down" },
+            { LLM_TENSOR_FFN_UP,          "blk.%d.ffn_up" },
+            { LLM_TENSOR_FFN_GATE_NORM_IN,"blk.%d.ffn_gate_norm_in" },
+            { LLM_TENSOR_FFN_UP_NORM_IN,  "blk.%d.ffn_up_norm_in" },
+            { LLM_TENSOR_FFN_DOWN_NORM_IN,"blk.%d.ffn_down_norm_in" },
         },
     },
     {
@@ -2672,6 +2707,14 @@ struct llama_layer {
     struct ggml_tensor * attn_sub_norm;
     struct ggml_tensor * attn_post_norm;
     struct ggml_tensor * ffn_sub_norm;
+    // per-projection input norms (BitNet per-projection RMSNorm)
+    struct ggml_tensor * attn_q_norm_in;
+    struct ggml_tensor * attn_k_norm_in;
+    struct ggml_tensor * attn_v_norm_in;
+    struct ggml_tensor * attn_out_norm_in;
+    struct ggml_tensor * ffn_gate_norm_in;
+    struct ggml_tensor * ffn_up_norm_in;
+    struct ggml_tensor * ffn_down_norm_in;
     struct ggml_tensor * attn_norm_cross;
     struct ggml_tensor * attn_norm_enc;
 
@@ -5912,6 +5955,17 @@ static void llm_load_hparams(
                     default: model.type = e_model::MODEL_UNKNOWN;
                }
             } break;
+        case LLM_ARCH_QWEN3:
+            {
+                ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
+                switch (hparams.n_layer) {
+                    case 28: model.type = hparams.n_embd == 1024 ? e_model::MODEL_0_5B : e_model::MODEL_2B; break;
+                    case 36: model.type = hparams.n_embd == 2560 ? e_model::MODEL_4B : e_model::MODEL_8B; break;
+                    case 40: model.type = e_model::MODEL_14B; break;
+                    case 64: model.type = e_model::MODEL_30B; break;
+                    default: model.type = e_model::MODEL_UNKNOWN;
+                }
+            } break;
         case LLM_ARCH_STARCODER2:
             {
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_EPS, hparams.f_norm_eps);
@@ -8269,6 +8323,54 @@ static bool llm_load_tensors(
                         layer.ffn_post_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_POST_NORM, "weight", i), {n_embd});
                     }
                 } break;
+            case LLM_ARCH_QWEN3:
+                {
+                    model.tok_embd = ml.create_tensor(ctx_input, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab});
+
+                    // output
+                    {
+                        model.output_norm = ml.create_tensor(ctx_output,       tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd});
+                        model.output      = ml.create_tensor(ctx_output_split, tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab}, llama_model_loader::TENSOR_NOT_REQUIRED);
+                        // if output is NULL, init from the input tok embed
+                        if (model.output == NULL) {
+                            model.output = ml.create_tensor(ctx_output, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, llama_model_loader::TENSOR_DUPLICATED);
+                        }
+                    }
+
+                    for (int i = 0; i < n_layer; ++i) {
+                        ggml_context * ctx_layer = ctx_for_layer(i);
+                        ggml_context * ctx_split = ctx_for_layer_split(i);
+
+                        auto & layer = model.layers[i];
+
+                        layer.attn_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd});
+
+                        layer.wq = ml.create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_Q,   "weight", i), {n_embd, n_embd_head_k * n_head});
+                        layer.wk = ml.create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_k_gqa});
+                        layer.wv = ml.create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_embd_v_gqa});
+                        layer.wo = ml.create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_k * n_head, n_embd});
+
+                        layer.attn_q_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), {n_embd_head_k});
+                        layer.attn_k_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k});
+
+                        // BitNet per-projection input norms (optional)
+                        layer.attn_q_norm_in   = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_Q_NORM_IN,   "weight", i), {n_embd},              llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.attn_k_norm_in   = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_K_NORM_IN,   "weight", i), {n_embd},              llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.attn_v_norm_in   = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_V_NORM_IN,   "weight", i), {n_embd},              llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.attn_out_norm_in = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_OUT_NORM_IN, "weight", i), {n_embd_head_k * n_head}, llama_model_loader::TENSOR_NOT_REQUIRED);
+
+                        layer.ffn_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd});
+
+                        layer.ffn_gate = ml.create_tensor(ctx_split, tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff});
+                        layer.ffn_down = ml.create_tensor(ctx_split, tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd});
+                        layer.ffn_up   = ml.create_tensor(ctx_split, tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd,   n_ff});
+
+                        // BitNet per-projection input norms for MLP (optional)
+                        layer.ffn_gate_norm_in = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_GATE_NORM_IN, "weight", i), {n_embd}, llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.ffn_up_norm_in   = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_UP_NORM_IN,   "weight", i), {n_embd}, llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.ffn_down_norm_in = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_DOWN_NORM_IN, "weight", i), {n_ff},   llama_model_loader::TENSOR_NOT_REQUIRED);
+                    }
+                } break;
             case LLM_ARCH_STARCODER2:
                 {
                     model.tok_embd = ml.create_tensor(ctx_input, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab});
@@ -9815,7 +9917,7 @@ static struct ggml_tensor * llm_build_kqv(
         struct ggml_tensor * kq = ggml_mul_mat(ctx, k, q);
         cb(kq, "kq", il);
 
-        if (model.arch == LLM_ARCH_PHI2 || model.arch == LLM_ARCH_PHI3 || model.arch == LLM_ARCH_GPTNEOX || model.arch == LLM_ARCH_QWEN2 || model.arch == LLM_ARCH_NEMOTRON || model.arch == LLM_ARCH_CHATGLM) {
+        if (model.arch == LLM_ARCH_PHI2 || model.arch == LLM_ARCH_PHI3 || model.arch == LLM_ARCH_GPTNEOX || model.arch == LLM_ARCH_QWEN2 || model.arch == LLM_ARCH_QWEN3 || model.arch == LLM_ARCH_NEMOTRON || model.arch == LLM_ARCH_CHATGLM) {
             // for this arch, we need to perform the KQ multiplication with F32 precision, otherwise we get NaNs
             // ref: https://github.com/ggerganov/llama.cpp/pull/4490#issuecomment-1859055847
             ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
@@ -12453,6 +12555,204 @@ struct llm_build_context {
                     NULL,
                     LLM_FFN_SILU, LLM_FFN_PAR, cb, il);
             cb(cur, "ffn_out", il);
+
+            cur = ggml_add(ctx0, cur, ffn_inp);
+            cur = lctx.cvec.apply_to(ctx0, cur, il);
+            cb(cur, "l_out", il);
+
+            // input for next layer
+            inpL = cur;
+        }
+
+        cur = inpL;
+
+        cur = llm_build_norm(ctx0, cur, hparams,
+                model.output_norm, NULL,
+                LLM_NORM_RMS, cb, -1);
+        cb(cur, "result_norm", -1);
+
+        // lm_head
+        cur = llm_build_lora_mm(lctx, ctx0, model.output, cur);
+        cb(cur, "result_output", -1);
+
+        ggml_build_forward_expand(gf, cur);
+
+        return gf;
+    }
+
+    struct ggml_cgraph * build_qwen3() {
+        struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, llama_model_max_nodes(model), false);
+
+        const int64_t n_embd_head = hparams.n_embd_head_v;
+        GGML_ASSERT(n_embd_head == hparams.n_embd_head_k);
+        GGML_ASSERT(n_embd_head == hparams.n_rot);
+
+        struct ggml_tensor * cur;
+        struct ggml_tensor * inpL;
+
+        inpL = llm_build_inp_embd(ctx0, lctx, hparams, batch, model.tok_embd, cb);
+
+        // inp_pos - contains the positions
+        struct ggml_tensor * inp_pos = build_inp_pos();
+
+        // KQ_mask (mask for 1 head, it will be broadcasted to all heads)
+        struct ggml_tensor * KQ_mask = build_inp_KQ_mask();
+
+        for (int il = 0; il < n_layer; ++il) {
+            struct ggml_tensor * inpSA = inpL;
+
+            // norm
+            cur = llm_build_norm(ctx0, inpL, hparams,
+                    model.layers[il].attn_norm, NULL,
+                    LLM_NORM_RMS, cb, il);
+            cb(cur, "attn_norm", il);
+
+            // self-attention
+            {
+                // Per-projection input norms (BitNet): apply RMSNorm before each projection
+                struct ggml_tensor * q_inp = cur;
+                struct ggml_tensor * k_inp = cur;
+                struct ggml_tensor * v_inp = cur;
+
+                if (model.layers[il].attn_q_norm_in) {
+                    q_inp = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].attn_q_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(q_inp, "attn_q_norm_in", il);
+                }
+                if (model.layers[il].attn_k_norm_in) {
+                    k_inp = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].attn_k_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(k_inp, "attn_k_norm_in", il);
+                }
+                if (model.layers[il].attn_v_norm_in) {
+                    v_inp = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].attn_v_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(v_inp, "attn_v_norm_in", il);
+                }
+
+                // compute Q and K and RoPE them
+                struct ggml_tensor * Qcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wq, q_inp);
+                cb(Qcur, "Qcur", il);
+
+                struct ggml_tensor * Kcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wk, k_inp);
+                cb(Kcur, "Kcur", il);
+
+                struct ggml_tensor * Vcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wv, v_inp);
+                cb(Vcur, "Vcur", il);
+
+                // reshape Q/K for norm
+                Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
+                Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
+
+                // Q/K norm
+                Qcur = llm_build_norm(ctx0, Qcur, hparams,
+                        model.layers[il].attn_q_norm, NULL,
+                        LLM_NORM_RMS, cb, il);
+                cb(Qcur, "Qcur_normed", il);
+
+                Kcur = llm_build_norm(ctx0, Kcur, hparams,
+                        model.layers[il].attn_k_norm, NULL,
+                        LLM_NORM_RMS, cb, il);
+                cb(Kcur, "Kcur_normed", il);
+
+                Qcur = ggml_rope_ext(
+                    ctx0, Qcur, inp_pos, nullptr,
+                    n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow
+                );
+                cb(Qcur, "Qcur", il);
+
+                Kcur = ggml_rope_ext(
+                    ctx0, Kcur, inp_pos, nullptr,
+                    n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow
+                );
+                cb(Kcur, "Kcur", il);
+
+                if (model.layers[il].attn_out_norm_in) {
+                    // Has per-projection norm for o_proj: do KV without wo, then norm + wo
+                    cur = llm_build_kv(ctx0, lctx, kv_self, gf,
+                            NULL, NULL,
+                            Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, 1.0f/sqrtf(float(n_embd_head)), cb, il);
+
+                    cur = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].attn_out_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(cur, "attn_out_norm_in", il);
+
+                    cur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wo, cur);
+                    cb(cur, "attn_o_out", il);
+                } else {
+                    cur = llm_build_kv(ctx0, lctx, kv_self, gf,
+                            model.layers[il].wo, NULL,
+                            Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, 1.0f/sqrtf(float(n_embd_head)), cb, il);
+                }
+            }
+
+            if (il == n_layer - 1) {
+                // skip computing output for unused tokens
+                struct ggml_tensor * inp_out_ids = build_inp_out_ids();
+                cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
+                inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
+            }
+
+            struct ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
+            cb(ffn_inp, "ffn_inp", il);
+
+            // feed-forward network
+            cur = llm_build_norm(ctx0, ffn_inp, hparams,
+                    model.layers[il].ffn_norm, NULL,
+                    LLM_NORM_RMS, cb, il);
+            cb(cur, "ffn_norm", il);
+
+            if (model.layers[il].ffn_gate_norm_in) {
+                // BitNet per-projection norms for MLP
+                struct ggml_tensor * gate_inp = llm_build_norm(ctx0, cur, hparams,
+                        model.layers[il].ffn_gate_norm_in, NULL,
+                        LLM_NORM_RMS, cb, il);
+                cb(gate_inp, "ffn_gate_norm_in", il);
+
+                struct ggml_tensor * up_inp = cur;
+                if (model.layers[il].ffn_up_norm_in) {
+                    up_inp = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].ffn_up_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(up_inp, "ffn_up_norm_in", il);
+                }
+
+                // gate: silu(gate_proj(gate_inp)) * up_proj(up_inp)
+                struct ggml_tensor * gate_out = llm_build_lora_mm(lctx, ctx0, model.layers[il].ffn_gate, gate_inp);
+                cb(gate_out, "ffn_gate", il);
+                gate_out = ggml_silu(ctx0, gate_out);
+                cb(gate_out, "ffn_silu", il);
+
+                struct ggml_tensor * up_out = llm_build_lora_mm(lctx, ctx0, model.layers[il].ffn_up, up_inp);
+                cb(up_out, "ffn_up", il);
+
+                cur = ggml_mul(ctx0, gate_out, up_out);
+                cb(cur, "ffn_gate_up", il);
+
+                if (model.layers[il].ffn_down_norm_in) {
+                    cur = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].ffn_down_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(cur, "ffn_down_norm_in", il);
+                }
+
+                cur = llm_build_lora_mm(lctx, ctx0, model.layers[il].ffn_down, cur);
+                cb(cur, "ffn_down", il);
+            } else {
+                cur = llm_build_ffn(ctx0, lctx, cur,
+                        model.layers[il].ffn_up,   NULL, NULL,
+                        model.layers[il].ffn_gate, NULL, NULL,
+                        model.layers[il].ffn_down, NULL, NULL,
+                        NULL,
+                        LLM_FFN_SILU, LLM_FFN_PAR, cb, il);
+                cb(cur, "ffn_out", il);
+            }
 
             cur = ggml_add(ctx0, cur, ffn_inp);
             cur = lctx.cvec.apply_to(ctx0, cur, il);
@@ -16747,6 +17047,10 @@ static struct ggml_cgraph * llama_build_graph(
             {
                 result = llm.build_qwen2();
             } break;
+        case LLM_ARCH_QWEN3:
+            {
+                result = llm.build_qwen3();
+            } break;
         case LLM_ARCH_QWEN2MOE:
             {
                 result = llm.build_qwen2moe();
@@ -20116,6 +20420,7 @@ enum llama_rope_type llama_rope_type(const struct llama_model * model) {
         case LLM_ARCH_BITNET_B158:
         case LLM_ARCH_QWEN:
         case LLM_ARCH_QWEN2:
+        case LLM_ARCH_QWEN3:
         case LLM_ARCH_QWEN2MOE:
         case LLM_ARCH_OLMOE:
         case LLM_ARCH_PHI2:

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -192,6 +192,7 @@ enum llm_arch {
     LLM_ARCH_MINICPM3,
     LLM_ARCH_GEMMA,
     LLM_ARCH_GEMMA2,
+    LLM_ARCH_GEMMA3,
     LLM_ARCH_STARCODER2,
     LLM_ARCH_MAMBA,
     LLM_ARCH_XVERSE,
@@ -248,6 +249,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
     { LLM_ARCH_MINICPM3,        "minicpm3"     },
     { LLM_ARCH_GEMMA,           "gemma"        },
     { LLM_ARCH_GEMMA2,          "gemma2"       },
+    { LLM_ARCH_GEMMA3,          "gemma3"       },
     { LLM_ARCH_STARCODER2,      "starcoder2"   },
     { LLM_ARCH_MAMBA,           "mamba"        },
     { LLM_ARCH_XVERSE,          "xverse"       },
@@ -1163,6 +1165,33 @@ static const std::map<llm_arch, std::map<llm_tensor, const char *>> LLM_TENSOR_N
             { LLM_TENSOR_FFN_GATE_NORM_IN,"blk.%d.ffn_gate_norm_in" },
             { LLM_TENSOR_FFN_UP_NORM_IN,  "blk.%d.ffn_up_norm_in" },
             { LLM_TENSOR_FFN_DOWN_NORM_IN,"blk.%d.ffn_down_norm_in" },
+        },
+    },
+    {
+        LLM_ARCH_GEMMA3,
+        {
+            { LLM_TENSOR_TOKEN_EMBD,      "token_embd" },
+            { LLM_TENSOR_OUTPUT_NORM,     "output_norm" },
+            { LLM_TENSOR_ATTN_NORM,       "blk.%d.attn_norm" },
+            { LLM_TENSOR_ATTN_Q,          "blk.%d.attn_q" },
+            { LLM_TENSOR_ATTN_K,          "blk.%d.attn_k" },
+            { LLM_TENSOR_ATTN_V,          "blk.%d.attn_v" },
+            { LLM_TENSOR_ATTN_OUT,        "blk.%d.attn_output" },
+            { LLM_TENSOR_ATTN_Q_NORM,     "blk.%d.attn_q_norm" },
+            { LLM_TENSOR_ATTN_K_NORM,     "blk.%d.attn_k_norm" },
+            { LLM_TENSOR_ATTN_Q_NORM_IN,  "blk.%d.attn_q_norm_in" },
+            { LLM_TENSOR_ATTN_K_NORM_IN,  "blk.%d.attn_k_norm_in" },
+            { LLM_TENSOR_ATTN_V_NORM_IN,  "blk.%d.attn_v_norm_in" },
+            { LLM_TENSOR_ATTN_OUT_NORM_IN,"blk.%d.attn_output_norm_in" },
+            { LLM_TENSOR_ATTN_POST_NORM,  "blk.%d.post_attention_norm" },
+            { LLM_TENSOR_FFN_NORM,        "blk.%d.ffn_norm" },
+            { LLM_TENSOR_FFN_GATE,        "blk.%d.ffn_gate" },
+            { LLM_TENSOR_FFN_DOWN,        "blk.%d.ffn_down" },
+            { LLM_TENSOR_FFN_UP,          "blk.%d.ffn_up" },
+            { LLM_TENSOR_FFN_GATE_NORM_IN,"blk.%d.ffn_gate_norm_in" },
+            { LLM_TENSOR_FFN_UP_NORM_IN,  "blk.%d.ffn_up_norm_in" },
+            { LLM_TENSOR_FFN_DOWN_NORM_IN,"blk.%d.ffn_down_norm_in" },
+            { LLM_TENSOR_FFN_POST_NORM,   "blk.%d.post_ffw_norm" },
         },
     },
     {
@@ -5966,6 +5995,18 @@ static void llm_load_hparams(
                     default: model.type = e_model::MODEL_UNKNOWN;
                 }
             } break;
+        case LLM_ARCH_GEMMA3:
+            {
+                ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
+                switch (hparams.n_layer) {
+                    case 18: model.type = e_model::MODEL_SMALL; break;
+                    case 26: model.type = e_model::MODEL_2B; break;
+                    case 38: model.type = e_model::MODEL_4B; break;
+                    case 48: model.type = e_model::MODEL_12B; break;
+                    case 64: model.type = e_model::MODEL_27B; break;
+                    default: model.type = e_model::MODEL_UNKNOWN;
+                }
+            } break;
         case LLM_ARCH_STARCODER2:
             {
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_EPS, hparams.f_norm_eps);
@@ -8371,6 +8412,51 @@ static bool llm_load_tensors(
                         layer.ffn_down_norm_in = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_DOWN_NORM_IN, "weight", i), {n_ff},   llama_model_loader::TENSOR_NOT_REQUIRED);
                     }
                 } break;
+            case LLM_ARCH_GEMMA3:
+                {
+                    model.tok_embd = ml.create_tensor(ctx_input, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab});
+
+                    // output
+                    model.output_norm = ml.create_tensor(ctx_output, tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd});
+                    model.output      = ml.create_tensor(ctx_output, tn(LLM_TENSOR_TOKEN_EMBD,  "weight"), {n_embd, n_vocab}, llama_model_loader::TENSOR_DUPLICATED);
+
+                    for (int i = 0; i < n_layer; ++i) {
+                        ggml_context * ctx_layer = ctx_for_layer(i);
+                        ggml_context * ctx_split = ctx_for_layer_split(i);
+
+                        auto & layer = model.layers[i];
+
+                        layer.attn_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd});
+
+                        layer.wq = ml.create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_Q,   "weight", i), {n_embd, n_embd_head_k * n_head});
+                        layer.wk = ml.create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_k_gqa});
+                        layer.wv = ml.create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_embd_v_gqa});
+                        layer.wo = ml.create_tensor(ctx_split, tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_k * n_head, n_embd});
+
+                        layer.attn_q_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), {n_embd_head_k});
+                        layer.attn_k_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k});
+
+                        // BitNet per-projection input norms (optional)
+                        layer.attn_q_norm_in   = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_Q_NORM_IN,   "weight", i), {n_embd},              llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.attn_k_norm_in   = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_K_NORM_IN,   "weight", i), {n_embd},              llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.attn_v_norm_in   = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_V_NORM_IN,   "weight", i), {n_embd},              llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.attn_out_norm_in = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_OUT_NORM_IN, "weight", i), {n_embd_head_k * n_head}, llama_model_loader::TENSOR_NOT_REQUIRED);
+
+                        layer.attn_post_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_ATTN_POST_NORM, "weight", i), {n_embd});
+
+                        layer.ffn_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd});
+                        layer.ffn_gate = ml.create_tensor(ctx_split, tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff});
+                        layer.ffn_up   = ml.create_tensor(ctx_split, tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd,   n_ff});
+                        layer.ffn_down = ml.create_tensor(ctx_split, tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd});
+
+                        // BitNet per-projection input norms for MLP (optional)
+                        layer.ffn_gate_norm_in = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_GATE_NORM_IN, "weight", i), {n_embd}, llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.ffn_up_norm_in   = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_UP_NORM_IN,   "weight", i), {n_embd}, llama_model_loader::TENSOR_NOT_REQUIRED);
+                        layer.ffn_down_norm_in = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_DOWN_NORM_IN, "weight", i), {n_ff},   llama_model_loader::TENSOR_NOT_REQUIRED);
+
+                        layer.ffn_post_norm = ml.create_tensor(ctx_layer, tn(LLM_TENSOR_FFN_POST_NORM, "weight", i), {n_embd});
+                    }
+                } break;
             case LLM_ARCH_STARCODER2:
                 {
                     model.tok_embd = ml.create_tensor(ctx_input, tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab});
@@ -9917,7 +10003,7 @@ static struct ggml_tensor * llm_build_kqv(
         struct ggml_tensor * kq = ggml_mul_mat(ctx, k, q);
         cb(kq, "kq", il);
 
-        if (model.arch == LLM_ARCH_PHI2 || model.arch == LLM_ARCH_PHI3 || model.arch == LLM_ARCH_GPTNEOX || model.arch == LLM_ARCH_QWEN2 || model.arch == LLM_ARCH_QWEN3 || model.arch == LLM_ARCH_NEMOTRON || model.arch == LLM_ARCH_CHATGLM) {
+        if (model.arch == LLM_ARCH_PHI2 || model.arch == LLM_ARCH_PHI3 || model.arch == LLM_ARCH_GPTNEOX || model.arch == LLM_ARCH_QWEN2 || model.arch == LLM_ARCH_QWEN3 || model.arch == LLM_ARCH_GEMMA3 || model.arch == LLM_ARCH_NEMOTRON || model.arch == LLM_ARCH_CHATGLM) {
             // for this arch, we need to perform the KQ multiplication with F32 precision, otherwise we get NaNs
             // ref: https://github.com/ggerganov/llama.cpp/pull/4490#issuecomment-1859055847
             ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
@@ -14329,6 +14415,218 @@ struct llm_build_context {
     }
 
 
+    struct ggml_cgraph * build_gemma3() {
+        struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, llama_model_max_nodes(model), false);
+
+        const int64_t n_embd_head_k = hparams.n_embd_head_k;
+
+        struct ggml_tensor * cur;
+        struct ggml_tensor * inpL;
+
+        inpL = llm_build_inp_embd(ctx0, lctx, hparams, batch, model.tok_embd, cb);
+
+        inpL = ggml_scale(ctx0, inpL, sqrtf(n_embd));
+        cb(inpL, "inp_scaled", -1);
+
+        // inp_pos - contains the positions
+        struct ggml_tensor * inp_pos = build_inp_pos();
+
+        // KQ_mask (mask for 1 head, it will be broadcasted to all heads)
+        struct ggml_tensor * KQ_mask = build_inp_KQ_mask();
+
+        for (int il = 0; il < n_layer; ++il) {
+            struct ggml_tensor * inpSA = inpL;
+
+            // norm
+            cur = llm_build_norm(ctx0, inpL, hparams,
+                    model.layers[il].attn_norm, NULL,
+                    LLM_NORM_RMS, cb, il);
+            cb(cur, "attn_norm", il);
+
+            // self-attention
+            {
+                // Per-projection input norms (BitNet): apply RMSNorm before each projection
+                struct ggml_tensor * q_inp = cur;
+                struct ggml_tensor * k_inp = cur;
+                struct ggml_tensor * v_inp = cur;
+
+                if (model.layers[il].attn_q_norm_in) {
+                    q_inp = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].attn_q_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(q_inp, "attn_q_norm_in", il);
+                }
+                if (model.layers[il].attn_k_norm_in) {
+                    k_inp = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].attn_k_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(k_inp, "attn_k_norm_in", il);
+                }
+                if (model.layers[il].attn_v_norm_in) {
+                    v_inp = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].attn_v_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(v_inp, "attn_v_norm_in", il);
+                }
+
+                // compute Q and K and RoPE them
+                struct ggml_tensor * Qcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wq, q_inp);
+                cb(Qcur, "Qcur", il);
+
+                struct ggml_tensor * Kcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wk, k_inp);
+                cb(Kcur, "Kcur", il);
+
+                struct ggml_tensor * Vcur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wv, v_inp);
+                cb(Vcur, "Vcur", il);
+
+                // reshape Q/K for head norms
+                Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head_k, n_head,    n_tokens);
+                Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head_k, n_head_kv, n_tokens);
+
+                // QK head norms
+                Qcur = llm_build_norm(ctx0, Qcur, hparams,
+                        model.layers[il].attn_q_norm, NULL,
+                        LLM_NORM_RMS, cb, il);
+                cb(Qcur, "Qcur_normed", il);
+
+                Kcur = llm_build_norm(ctx0, Kcur, hparams,
+                        model.layers[il].attn_k_norm, NULL,
+                        LLM_NORM_RMS, cb, il);
+                cb(Kcur, "Kcur_normed", il);
+
+                Qcur = ggml_rope_ext(
+                        ctx0, Qcur, inp_pos, nullptr,
+                        n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                        ext_factor, attn_factor, beta_fast, beta_slow);
+                cb(Qcur, "Qcur", il);
+
+                // Gemma3: use query_pre_attn_scalar for attention scaling
+                Qcur = ggml_scale(ctx0, Qcur, 1.0f / sqrtf(float(n_embd_head_k)));
+                cb(Qcur, "Qcur_scaled", il);
+
+                Kcur = ggml_rope_ext(
+                        ctx0, Kcur, inp_pos, nullptr,
+                        n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                        ext_factor, attn_factor, beta_fast, beta_slow);
+                cb(Kcur, "Kcur", il);
+
+                if (model.layers[il].attn_out_norm_in) {
+                    // Has per-projection norm for o_proj: do KV without wo, then norm + wo
+                    cur = llm_build_kv(ctx0, lctx, kv_self, gf,
+                            NULL, NULL,
+                            Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, 1.0f, cb, il);
+
+                    cur = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].attn_out_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(cur, "attn_out_norm_in", il);
+
+                    cur = llm_build_lora_mm(lctx, ctx0, model.layers[il].wo, cur);
+                    cb(cur, "attn_o_out", il);
+                } else {
+                    cur = llm_build_kv(ctx0, lctx, kv_self, gf,
+                            model.layers[il].wo, NULL,
+                            Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, 1.0f, cb, il);
+                }
+            }
+
+            cur = llm_build_norm(ctx0, cur, hparams,
+                    model.layers[il].attn_post_norm, NULL,
+                    LLM_NORM_RMS, cb, il);
+            cb(cur, "attn_post_norm", il);
+
+            if (il == n_layer - 1) {
+                // skip computing output for unused tokens
+                struct ggml_tensor * inp_out_ids = build_inp_out_ids();
+                cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
+                inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
+            }
+
+            struct ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
+            cb(ffn_inp, "ffn_inp", il);
+
+            // feed-forward network
+            cur = llm_build_norm(ctx0, ffn_inp, hparams,
+                    model.layers[il].ffn_norm, NULL,
+                    LLM_NORM_RMS, cb, il);
+            cb(cur, "ffn_norm", il);
+
+            if (model.layers[il].ffn_gate_norm_in) {
+                // BitNet per-projection norms for MLP
+                struct ggml_tensor * gate_inp = llm_build_norm(ctx0, cur, hparams,
+                        model.layers[il].ffn_gate_norm_in, NULL,
+                        LLM_NORM_RMS, cb, il);
+                cb(gate_inp, "ffn_gate_norm_in", il);
+
+                struct ggml_tensor * up_inp = cur;
+                if (model.layers[il].ffn_up_norm_in) {
+                    up_inp = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].ffn_up_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(up_inp, "ffn_up_norm_in", il);
+                }
+
+                // gate: gelu(gate_proj(gate_inp)) * up_proj(up_inp)
+                struct ggml_tensor * gate_out = llm_build_lora_mm(lctx, ctx0, model.layers[il].ffn_gate, gate_inp);
+                cb(gate_out, "ffn_gate", il);
+                gate_out = ggml_gelu(ctx0, gate_out);
+                cb(gate_out, "ffn_gelu", il);
+
+                struct ggml_tensor * up_out = llm_build_lora_mm(lctx, ctx0, model.layers[il].ffn_up, up_inp);
+                cb(up_out, "ffn_up", il);
+
+                cur = ggml_mul(ctx0, gate_out, up_out);
+                cb(cur, "ffn_gate_up", il);
+
+                if (model.layers[il].ffn_down_norm_in) {
+                    cur = llm_build_norm(ctx0, cur, hparams,
+                            model.layers[il].ffn_down_norm_in, NULL,
+                            LLM_NORM_RMS, cb, il);
+                    cb(cur, "ffn_down_norm_in", il);
+                }
+
+                cur = llm_build_lora_mm(lctx, ctx0, model.layers[il].ffn_down, cur);
+                cb(cur, "ffn_down", il);
+            } else {
+                cur = llm_build_ffn(ctx0, lctx, cur,
+                        model.layers[il].ffn_up,   NULL, NULL,
+                        model.layers[il].ffn_gate, NULL, NULL,
+                        model.layers[il].ffn_down, NULL, NULL,
+                        NULL,
+                        LLM_FFN_GELU, LLM_FFN_PAR, cb, il);
+                cb(cur, "ffn_out", il);
+            }
+
+            cur = llm_build_norm(ctx0, cur, hparams,
+                model.layers[il].ffn_post_norm, NULL,
+                LLM_NORM_RMS, cb, -1);
+            cb(cur, "ffn_post_norm", -1);
+
+            cur = ggml_add(ctx0, cur, ffn_inp);
+            cur = lctx.cvec.apply_to(ctx0, cur, il);
+            cb(cur, "l_out", il);
+
+            // input for next layer
+            inpL = cur;
+        }
+
+        cur = inpL;
+
+        cur = llm_build_norm(ctx0, cur, hparams,
+                model.output_norm, NULL,
+                LLM_NORM_RMS, cb, -1);
+        cb(cur, "result_norm", -1);
+
+        // lm_head
+        cur = llm_build_lora_mm(lctx, ctx0, model.output, cur);
+        cb(cur, "result_output", -1);
+
+        ggml_build_forward_expand(gf, cur);
+
+        return gf;
+    }
+
+
     struct ggml_cgraph * build_starcoder2() {
         struct ggml_cgraph * gf = ggml_new_graph_custom(ctx0, llama_model_max_nodes(model), false);
 
@@ -17098,6 +17396,10 @@ static struct ggml_cgraph * llama_build_graph(
         case LLM_ARCH_GEMMA2:
             {
                 result = llm.build_gemma2();
+            } break;
+        case LLM_ARCH_GEMMA3:
+            {
+                result = llm.build_gemma3();
             } break;
         case LLM_ARCH_STARCODER2:
             {
@@ -20427,6 +20729,7 @@ enum llama_rope_type llama_rope_type(const struct llama_model * model) {
         case LLM_ARCH_PHI3:
         case LLM_ARCH_GEMMA:
         case LLM_ARCH_GEMMA2:
+        case LLM_ARCH_GEMMA3:
         case LLM_ARCH_STARCODER2:
         case LLM_ARCH_OPENELM:
         case LLM_ARCH_GPTNEOX:


### PR DESCRIPTION
- Add LLM_ARCH_GEMMA3 with QK head norms, pre/post FFN norms, and post-attention norm
- Add 7 per-projection BitNet norm_in tensors (shared enums with Qwen3)
- Add build_gemma3() combining Gemma2 structure with per-projection norm pattern
- Add I2_S quantization type and f16 norm weight mul support in ggml.c
- Guard bitnet-lut-kernels.h include with TL1/TL2 preprocessor check



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
